### PR TITLE
Migrated common enums needed for processing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+<!-- Brief explanation of the PR and its purpose -->
+
+## Related issues
+<!-- Which issue(s) does this PR close, resolve or fix. Use Closes #123. Use "Resolves, Closes, or Fixes" to auto-close the issue. -->
+Resolves #
+
+## Overview of changes
+<!-- Provide a summary of key changes -->
+
+#### Describe changes related to the issue(s):
+- Change one
+- Change two
+
+#### Describe any opportune refactorings, if any:
+- Change one

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Version and release library
+name: Release
 
 on:
   workflow_dispatch:
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      pull-requests: read
 
     steps:
       - name: Checkout code
@@ -30,6 +31,16 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: maven
+
+      - name: Install GitHub CLI
+        run: |
+          sudo apt update
+          sudo apt install -y gh
+
+      - name: Authenticate GitHub CLI
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
       - name: Configure maven repository server
         run: |
@@ -98,9 +109,18 @@ jobs:
           echo "Previous tag: $PREV_TAG"
           
           if [ -n "$PREV_TAG" ]; then
-            git log $PREV_TAG..HEAD --pretty=format:"- %s (%an)" > CHANGELOG.md
+            gh pr list \
+              --state merged \
+              --search "merged:>${PREV_TAG}" \
+              --limit 100 \
+              --json title,number,author \
+              --jq '.[] | "- \(.title) (#\(.number) by \(.author.login))"' > CHANGELOG.md
           else
-            git log --pretty=format:"- %s (%an)" > CHANGELOG.md
+            gh pr list \
+              --state merged \
+              --limit 100 \
+              --json title,number,author \
+              --jq '.[] | "- \(.title) (#\(.number) by \(.author.login))"' > CHANGELOG.md
           fi
           
           echo "Generated changelog:"

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <distributionManagement>

--- a/src/main/java/com/doubletuck/gym/common/model/AcademicYear.java
+++ b/src/main/java/com/doubletuck/gym/common/model/AcademicYear.java
@@ -1,0 +1,50 @@
+package com.doubletuck.gym.common.model;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+@Getter
+public enum AcademicYear {
+
+    FR("Freshman", "Fr."),
+    REDSHIRT_FR("Redshirt Freshman", "R-Fr.", "RS Fr.", "R-Freshman"),
+    SO("Sophomore", "So."),
+    REDSHIRT_SO("Redshirt Sophomore", "R-So.", "RS So.", "R-Sophomore"),
+    JR("Junior", "Jr."),
+    REDSHIRT_JR("Redshirt Junior", "R-Jr.", "RS Jr.", "R-Junior"),
+    SR("Senior", "Sr."),
+    REDSHIRT_SR("Redshirt Senior", "R-Sr.", "RS Sr.", "R-Senior"),
+    FIFTH_YR("Fifth Year", "5th-Year Senior", "5th", "Fifth"),
+    SIXTH_YR("Sixth Year", "6th"),
+    GR("Graduate Student", "Graduate", "Gr."),
+    REDSHIRT("Redshirt", "Rs.");
+
+    private final String longName;
+    private final String[] otherNames;
+
+    AcademicYear(String longName, String... otherNames) {
+        this.longName = longName;
+        this.otherNames = otherNames;
+    }
+
+    /**
+     * Returns the academic year enum that matches the given text.
+     *
+     * @param   text The academic year code or name.
+     * @return  The AcademicYear enum that matches the given text or
+     *          null if no matches are found.
+     */
+    public static AcademicYear find(String text) {
+        if (text != null && !text.isBlank()) {
+            text = text.trim();
+            for (AcademicYear AcademicYear : values()) {
+                if (AcademicYear.name().equalsIgnoreCase(text) ||
+                        AcademicYear.longName.equalsIgnoreCase(text) ||
+                        StringUtils.equalsAnyIgnoreCase(text, AcademicYear.otherNames)) {
+                    return AcademicYear;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/doubletuck/gym/common/model/College.java
+++ b/src/main/java/com/doubletuck/gym/common/model/College.java
@@ -1,0 +1,33 @@
+package com.doubletuck.gym.common.model;
+
+public enum College {
+
+    ALABAMA,
+    ARIZONA,
+    ARIZONASTATE,
+    ARKANSAS,
+    AUBURN,
+    CLEMSON,
+    DENVER,
+    FLORIDA,
+    GEORGIA,
+    IOWA,
+    KENTUCKY,
+    LSU,
+    MICHIGAN,
+    MICHIGANSTATE,
+    MINNESOTA,
+    MISSOURI,
+    NCSTATE,
+    OHIOSTATE,
+    OKLAHOMA,
+    OREGONSTATE,
+    PENNSTATE,
+    STANFORD,
+    SOUTHERNUTAH,
+    UCBERKELEY,
+    UCLA,
+    UMDCOLLEGEPARK,
+    UNCCHAPELHILL,
+    UTAH
+}

--- a/src/main/java/com/doubletuck/gym/common/model/Event.java
+++ b/src/main/java/com/doubletuck/gym/common/model/Event.java
@@ -1,0 +1,44 @@
+package com.doubletuck.gym.common.model;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+@Getter
+public enum Event {
+
+    AA("All-Around", "All Around"),
+    VT("Vault", "V"),
+    UB("Uneven Bars", "Bars"),
+    BB("Balance Beam", "Beam"),
+    FX("Floor Exercise", "Floor");
+
+    private final String longName;
+    private final String[] otherNames;
+
+    Event(String longName, String... otherNames) {
+        this.longName = longName;
+        this.otherNames = otherNames;
+    }
+
+    /**
+     * Returns the Event enum that matches the given text.
+     *
+     * @param   text Case insensitive text that matches the value name,
+     *          long name or other names associated with the enum value.
+     * @return  The Event enum that matches the given text or null if
+     *          no matches are found.
+     */
+    public static Event find(String text) {
+        if (text != null && !text.isEmpty()) {
+            text = text.trim();
+            for (Event Event : values()) {
+                if (Event.name().equalsIgnoreCase(text) ||
+                        Event.longName.equalsIgnoreCase(text) ||
+                        StringUtils.equalsAnyIgnoreCase(text, Event.otherNames)) {
+                    return Event;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/doubletuck/gym/common/model/StaffRole.java
+++ b/src/main/java/com/doubletuck/gym/common/model/StaffRole.java
@@ -1,0 +1,30 @@
+package com.doubletuck.gym.common.model;
+
+import lombok.Getter;
+
+@Getter
+public enum StaffRole {
+
+    HEAD_COACH("Head Coach"),
+    ACTING_HEAD_COACH("Acting Head Coach"),
+    ASSOC_HEAD_COACH("Associate Head Coach"),
+    ASST_HEAD_COACH("Assistant Head Coach"),
+    FIRST_ASST_COACH("First Assistant Coach"),
+    ASST_COACH("Assistant Coach"),
+    ACTING_ASST_COACH("Acting Assistant Coach"),
+    INTERIM_ASST_COACH("Interim Assistant Coach"),
+    GRADUATE_ASST_COACH("Graduate Student Assistant Coach"),
+    GRADUATE_COACH("Graduate Student Coach"),
+    STUDENT_ASST_COACH("Student Assistant Coach"),
+    STUDENT_COACH("Student Coach"),
+    UNDERGRAD_ASST_COACH("Undergraduate Student Assistant Coach"),
+    UNDERGRAD_COACH("Undergraduate Student Coach"),
+    VOLUNTEER_ASST_COACH("Volunteer Assistant Coach"),
+    VOLUNTEER_COACH("Volunteer Coach");
+
+    private final String longName;
+
+    StaffRole(String longName) {
+        this.longName = longName;
+    }
+}

--- a/src/main/java/com/doubletuck/gym/common/model/State.java
+++ b/src/main/java/com/doubletuck/gym/common/model/State.java
@@ -1,0 +1,93 @@
+package com.doubletuck.gym.common.model;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+@Getter
+public enum State {
+
+    AL("Alabama", "Ala"),
+    AK("Alaska"),
+    AZ("Arizona", "Ariz"),
+    AR("Arkansas", "Ark"),
+    CA("California", "Calif"),
+    CO("Colorado", "Colo"),
+    CT("Connecticut", "Conn"),
+    DE("Delaware", "Del"),
+    DC("District of Columbia"),
+    FL("Florida", "Fla"),
+    GA("Georgia"),
+    HI("Hawaii", "Hawai'i"),
+    ID("Idaho"),
+    IL("Illinois", "Ill"),
+    IN("Indiana", "Ind"),
+    IA("Iowa"),
+    KS("Kansas", "Kan"),
+    KY("Kentucky"),
+    LA("Louisiana"),
+    ME("Maine"),
+    MD("Maryland"),
+    MA("Massachusetts", "Mass"),
+    MI("Michigan", "Mich"),
+    MN("Minnesota", "Minn", "Min"),
+    MS("Mississippi", "Miss"),
+    MO("Missouri"),
+    MT("Montana", "Mont"),
+    NE("Nebraska", "Neb"),
+    NV("Nevada", "Nev"),
+    NH("New Hampshire"),
+    NJ("New Jersey"),
+    NM("New Mexico"),
+    NY("New York"),
+    NC("North Carolina"),
+    ND("North Dakota"),
+    OH("Ohio"),
+    OK("Oklahoma", "Okla"),
+    OR("Oregon", "Ore"),
+    PA("Pennsylvania", "Penn"),
+    PR("Puerto Rico"),
+    RI("Rhode Island"),
+    SC("South Carolina"),
+    SD("South Dakota"),
+    TN("Tennessee", "Tenn"),
+    TX("Texas", "Tex"),
+    UT("Utah"),
+    VT("Vermont"),
+    VA("Virginia"),
+    WA("Washington", "Wash"),
+    WV("West Virginia", "WVa"),
+    WI("Wisconsin", "Wis", "Wisc"),
+    WY("Wyoming", "Wyo");
+
+    private final String longName;
+    private final String[] otherNames;
+
+    State(String longName, String... otherNames) {
+        this.longName = longName;
+        this.otherNames = otherNames;
+    }
+
+    /**
+     * Returns the State enum that matches the given text.
+     *
+     * @param   text Case-insensitive text that matches the enum value,
+     *          long name, or one of the other names.
+     * @return  The State enum that matches the given text or null if no
+     *          matches are found.
+     */
+    public static State find(String text) {
+
+        if (text != null && !text.isEmpty()) {
+            text = text.trim().replace(".","");
+            for (State state : State.values()) {
+                if (state.name().equalsIgnoreCase(text) ||
+                        state.longName.equalsIgnoreCase(text) ||
+                        StringUtils.equalsAnyIgnoreCase(text, state.otherNames)) {
+                    return state;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/test/java/com/doubletuck/gym/common/model/AcademicYearTest.java
+++ b/src/test/java/com/doubletuck/gym/common/model/AcademicYearTest.java
@@ -1,0 +1,137 @@
+package com.doubletuck.gym.common.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class AcademicYearTest {
+
+    @Test
+    public void findWhenInputIsEmpty() {
+        assertNull(AcademicYear.find(""), "Empty string");
+        assertNull(AcademicYear.find("   "), "Multiple empty spaces");
+    }
+
+    @Test
+    public void findWhenInputIsNull() {
+        assertNull(AcademicYear.find(null));
+    }
+
+    @Test
+    public void findLongNameDespiteCase() {
+        assertEquals(AcademicYear.GR, AcademicYear.find("graduate student"), "Lower case");
+        assertEquals(AcademicYear.GR, AcademicYear.find("GRADUATE STUDENT"), "Upper case");
+        assertEquals(AcademicYear.GR, AcademicYear.find("graDUaTe STudenT"), "Mixed case");
+    }
+
+    @Test
+    public void findOtherNameDespiteCase() {
+        assertEquals(AcademicYear.GR, AcademicYear.find("graduate"), "Other name - Graduate - Lower case");
+        assertEquals(AcademicYear.GR, AcademicYear.find("GRADUATE"), "Other name - Graduate - Upper case");
+        assertEquals(AcademicYear.GR, AcademicYear.find("graDUaTe"), "Other name - Graduate - Mixed case");
+        assertEquals(AcademicYear.GR, AcademicYear.find("gr."), "Other name - Gr - Lower case");
+        assertEquals(AcademicYear.GR, AcademicYear.find("GR."), "Other name - Gr - Upper case");
+        assertEquals(AcademicYear.GR, AcademicYear.find("gR."), "Other name - Gr - Mixed case");
+    }
+
+    @Test
+    public void findFreshman() {
+        assertEquals(AcademicYear.FR, AcademicYear.find("FR"), "By Name");
+        assertEquals(AcademicYear.FR, AcademicYear.find("Freshman"), "By Long Name");
+        assertEquals(AcademicYear.FR, AcademicYear.find("Fr."), "By Other Name");
+    }
+
+    @Test
+    public void findRedshirtFreshman() {
+        assertEquals(AcademicYear.REDSHIRT_FR, AcademicYear.find("REDSHIRT_FR"), "By Name");
+        assertEquals(AcademicYear.REDSHIRT_FR, AcademicYear.find("Redshirt Freshman"), "By Long Name");
+        assertEquals(AcademicYear.REDSHIRT_FR, AcademicYear.find("R-Fr."), "By Other Name - R-Fr.");
+        assertEquals(AcademicYear.REDSHIRT_FR, AcademicYear.find("RS Fr."), "By Other Name - RS Fr.");
+        assertEquals(AcademicYear.REDSHIRT_FR, AcademicYear.find("R-Freshman"), "By Other Name - R-Freshman");
+    }
+
+    @Test
+    public void findSophomore() {
+        assertEquals(AcademicYear.SO, AcademicYear.find("SO"), "By Name");
+        assertEquals(AcademicYear.SO, AcademicYear.find("Sophomore"), "By Long Name");
+        assertEquals(AcademicYear.SO, AcademicYear.find("So."), "By Other Name");
+    }
+
+    @Test
+    public void findRedshirtSophomore() {
+        assertEquals(AcademicYear.REDSHIRT_SO, AcademicYear.find("REDSHIRT_SO"), "By Name");
+        assertEquals(AcademicYear.REDSHIRT_SO, AcademicYear.find("Redshirt Sophomore"), "By Long Name");
+        assertEquals(AcademicYear.REDSHIRT_SO, AcademicYear.find("R-So."), "By Other Name - R-So.");
+        assertEquals(AcademicYear.REDSHIRT_SO, AcademicYear.find("RS So."), "By Other Name - RS So.");
+        assertEquals(AcademicYear.REDSHIRT_SO, AcademicYear.find("R-Sophomore"), "By Other Name - R-Sophomore");
+    }
+
+    @Test
+    public void findJunior() {
+        assertEquals(AcademicYear.JR, AcademicYear.find("JR"), "By Name");
+        assertEquals(AcademicYear.JR, AcademicYear.find("Junior"), "By Long Name");
+        assertEquals(AcademicYear.JR, AcademicYear.find("Jr."), "By Other Name");
+    }
+
+    @Test
+    public void findRedshirtJunior() {
+        assertEquals(AcademicYear.REDSHIRT_JR, AcademicYear.find("REDSHIRT_JR"), "By Name");
+        assertEquals(AcademicYear.REDSHIRT_JR, AcademicYear.find("Redshirt Junior"), "By Long Name");
+        assertEquals(AcademicYear.REDSHIRT_JR, AcademicYear.find("R-Jr."), "By Other Name - R-Jr.");
+        assertEquals(AcademicYear.REDSHIRT_JR, AcademicYear.find("RS Jr."), "By Other Name - RS Jr.");
+        assertEquals(AcademicYear.REDSHIRT_JR, AcademicYear.find("R-Junior"), "By Other Name - R-Junior");
+    }
+
+    @Test
+    public void findSenior() {
+        assertEquals(AcademicYear.SR, AcademicYear.find("SR"), "By Name");
+        assertEquals(AcademicYear.SR, AcademicYear.find("Senior"), "By Long Name");
+        assertEquals(AcademicYear.SR, AcademicYear.find("Sr."), "By Other Name");
+    }
+
+    @Test
+    public void findRedshirtSenior() {
+        assertEquals(AcademicYear.REDSHIRT_SR, AcademicYear.find("REDSHIRT_SR"), "By Name");
+        assertEquals(AcademicYear.REDSHIRT_SR, AcademicYear.find("Redshirt Senior"), "By Long Name");
+        assertEquals(AcademicYear.REDSHIRT_SR, AcademicYear.find("R-Sr."), "By Other Name - R-Sr.");
+        assertEquals(AcademicYear.REDSHIRT_SR, AcademicYear.find("RS Sr."), "By Other Name - RS Sr.");
+        assertEquals(AcademicYear.REDSHIRT_SR, AcademicYear.find("R-Senior"), "By Other Name - R-Senior");
+    }
+
+    @Test
+    public void findFifthYear() {
+        assertEquals(AcademicYear.FIFTH_YR, AcademicYear.find("FIFTH_YR"), "By Name");
+        assertEquals(AcademicYear.FIFTH_YR, AcademicYear.find("Fifth Year"), "By Long Name");
+        assertEquals(AcademicYear.FIFTH_YR, AcademicYear.find("5th-Year Senior"), "By Other Name - 5th-Year Senior");
+        assertEquals(AcademicYear.FIFTH_YR, AcademicYear.find("5th"), "By Other Name - 5th");
+        assertEquals(AcademicYear.FIFTH_YR, AcademicYear.find("Fifth"), "By Other Name - Fifth");
+    }
+
+    @Test
+    public void findSixthYear() {
+        assertEquals(AcademicYear.SIXTH_YR, AcademicYear.find("SIXTH_YR"), "By Name");
+        assertEquals(AcademicYear.SIXTH_YR, AcademicYear.find("Sixth Year"), "By Long Name");
+        assertEquals(AcademicYear.SIXTH_YR, AcademicYear.find("6th"), "By Other Name - 6th");
+    }
+
+    @Test
+    public void findGraduateStudent() {
+        assertEquals(AcademicYear.GR, AcademicYear.find("GR"), "By Name");
+        assertEquals(AcademicYear.GR, AcademicYear.find("Graduate Student"), "By Long Name");
+        assertEquals(AcademicYear.GR, AcademicYear.find("Graduate"), "By Other Name - Graduate");
+        assertEquals(AcademicYear.GR, AcademicYear.find("Gr."), "By Other Name - Gr.");
+    }
+
+    @Test
+    public void findRedshirt() {
+        assertEquals(AcademicYear.REDSHIRT, AcademicYear.find("REDSHIRT"), "By Name");
+        assertEquals(AcademicYear.REDSHIRT, AcademicYear.find("Redshirt"), "By Long Name");
+        assertEquals(AcademicYear.REDSHIRT, AcademicYear.find("Rs."), "By Other Name");
+    }
+
+    @Test
+    public void findWhenNotMatching() {
+        assertNull(AcademicYear.find("BOGUS"));
+    }
+}

--- a/src/test/java/com/doubletuck/gym/common/model/EventTest.java
+++ b/src/test/java/com/doubletuck/gym/common/model/EventTest.java
@@ -1,0 +1,73 @@
+package com.doubletuck.gym.common.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class EventTest {
+    @Test
+    public void findWhenInputIsEmpty() {
+        assertNull(Event.find(""), "Empty string");
+        assertNull(Event.find("     "), "Multiple empty spaces");
+    }
+
+    @Test
+    public void findWhenInputIsNull() {
+        assertNull(Event.find(null));
+    }
+
+    @Test
+    public void findLongNameDespiteCase() {
+        assertEquals(Event.VT, Event.find("vault"), "Lower case");
+        assertEquals(Event.VT, Event.find("VAULT"), "Upper case");
+        assertEquals(Event.VT, Event.find("vAuLt"), "Random case");
+    }
+
+    @Test
+    public void findOtherNameDespiteCase() {
+        assertEquals(Event.UB, Event.find("bars"), "Lower case");
+        assertEquals(Event.UB, Event.find("BARS"), "Upper case");
+        assertEquals(Event.UB, Event.find("bArS"), "Random case");
+    }
+
+    @Test
+    public void findWhenNotMatching() {
+        assertNull(Event.find("BOGUS"));
+    }
+
+    @Test
+    public void findAllAround() {
+        assertEquals(Event.AA, Event.find("AA"), "Name");
+        assertEquals(Event.AA, Event.find("All-Around"), "Long name");
+        assertEquals(Event.AA, Event.find("All Around"), "Other names");
+    }
+
+    @Test
+    public void findVault() {
+        assertEquals(Event.VT, Event.find("VT"), "Name");
+        assertEquals(Event.VT, Event.find("Vault"), "Long name");
+        assertEquals(Event.VT, Event.find("V"), "Other names");
+    }
+
+    @Test
+    public void findUnevenBars() {
+        assertEquals(Event.UB, Event.find("UB"), "Name");
+        assertEquals(Event.UB, Event.find("Uneven Bars"), "Long name");
+        assertEquals(Event.UB, Event.find("Bars"), "Other names");
+    }
+
+    @Test
+    public void findBalanceBeam() {
+        assertEquals(Event.BB, Event.find("BB"), "Name");
+        assertEquals(Event.BB, Event.find("Balance Beam"), "Long name");
+        assertEquals(Event.BB, Event.find("Beam"), "Other names");
+    }
+
+    @Test
+    public void findFloorExercise() {
+        assertEquals(Event.FX, Event.find("FX"), "Name");
+        assertEquals(Event.FX, Event.find("Floor Exercise"), "Long name");
+        assertEquals(Event.FX, Event.find("Floor"), "Other names");
+    }
+}

--- a/src/test/java/com/doubletuck/gym/common/model/StateTest.java
+++ b/src/test/java/com/doubletuck/gym/common/model/StateTest.java
@@ -1,0 +1,431 @@
+package com.doubletuck.gym.common.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class StateTest {
+
+    @Test
+    public void findWhenInputIsEmpty() {
+        assertNull(State.find(""), "Empty string");
+        assertNull(State.find("     "), "Multiple empty spaces");
+    }
+
+    @Test
+    public void findWhenInputIsNull() {
+        assertNull(State.find(null));
+    }
+
+    @Test
+    public void findByShortName() {
+        assertEquals(State.AL, State.find("AL"), "Uppercase");
+        assertEquals(State.AL, State.find("al"), "Lowercase");
+        assertEquals(State.AL, State.find("aL"), "Mixed case");
+    }
+
+    @Test
+    public void findByLongName() {
+        assertEquals(State.AL, State.find("ALABAMA"), "Uppercase");
+        assertEquals(State.AL, State.find("alabama"), "Lowercase");
+        assertEquals(State.AL, State.find("aLABamA"), "Mixed case");
+    }
+
+    @Test
+    public void findByOtherName() {
+        assertEquals(State.AL, State.find("ALA"), "Uppercase");
+        assertEquals(State.AL, State.find("ala"), "Lowercase");
+        assertEquals(State.AL, State.find("aLA"), "Mixed case");
+        assertEquals(State.AL, State.find("Ala."), "With period");
+        assertEquals(State.AL, State.find("A.l.a."), "Lots of periods");
+    }
+
+    @Test
+    public void findAlabama() {
+        assertEquals(State.AL, State.find("AL"), "Short Name");
+        assertEquals(State.AL, State.find("Alabama"), "Long Name");
+        assertEquals(State.AL, State.find("Ala"), "Other Name");
+        assertEquals(State.AL, State.find("Ala."), "AP Name");
+    }
+
+    @Test
+    public void findAlaska() {
+        assertEquals(State.AK, State.find("AK"), "Short Name");
+        assertEquals(State.AK, State.find("Alaska"), "Long Name");
+    }
+
+    @Test
+    public void findArizona() {
+        assertEquals(State.AZ, State.find("AZ"), "Short Name");
+        assertEquals(State.AZ, State.find("Arizona"), "Long Name");
+        assertEquals(State.AZ, State.find("Ariz"), "Other Name");
+        assertEquals(State.AZ, State.find("Ariz."), "AP Name");
+    }
+
+    @Test
+    public void findArkansas() {
+        assertEquals(State.AR, State.find("AR"), "Short Name");
+        assertEquals(State.AR, State.find("Arkansas"), "Long Name");
+        assertEquals(State.AR, State.find("Ark"), "Other Name");
+        assertEquals(State.AR, State.find("Ark."), "AP Name");
+    }
+
+    @Test
+    public void findCalifornia() {
+        assertEquals(State.CA, State.find("CA"), "Short Name");
+        assertEquals(State.CA, State.find("California"), "Long Name");
+        assertEquals(State.CA, State.find("Calif"), "Other Name");
+        assertEquals(State.CA, State.find("Calif."), "AP Name");
+    }
+
+    @Test
+    public void findColorado() {
+        assertEquals(State.CO, State.find("CO"), "Short Name");
+        assertEquals(State.CO, State.find("Colorado"), "Long Name");
+        assertEquals(State.CO, State.find("Colo"), "Other Name");
+        assertEquals(State.CO, State.find("Colo."), "AP Name");
+    }
+
+    @Test
+    public void findConnecticut() {
+        assertEquals(State.CT, State.find("CT"), "Short Name");
+        assertEquals(State.CT, State.find("Connecticut"), "Long Name");
+        assertEquals(State.CT, State.find("Conn"), "Other Name");
+        assertEquals(State.CT, State.find("Conn."), "AP Name");
+    }
+
+    @Test
+    public void findDelaware() {
+        assertEquals(State.DE, State.find("DE"), "Short Name");
+        assertEquals(State.DE, State.find("Delaware"), "Long Name");
+        assertEquals(State.DE, State.find("Del"), "Other Name");
+        assertEquals(State.DE, State.find("Del."), "AP Name");
+    }
+
+    @Test
+    public void findDistrictOfColumbia() {
+        assertEquals(State.DC, State.find("DC"), "Short Name");
+        assertEquals(State.DC, State.find("District of Columbia"), "Long Name");
+        assertEquals(State.DC, State.find("D.C."), "AP Name");
+    }
+
+    @Test
+    public void findFlorida() {
+        assertEquals(State.FL, State.find("FL"), "Short Name");
+        assertEquals(State.FL, State.find("Florida"), "Long Name");
+        assertEquals(State.FL, State.find("Fla"), "Other Name");
+        assertEquals(State.FL, State.find("Fla."), "AP Name");
+    }
+
+    @Test
+    public void findGeorgia() {
+        assertEquals(State.GA, State.find("GA"), "Short Name");
+        assertEquals(State.GA, State.find("Georgia"), "Long Name");
+        assertEquals(State.GA, State.find("Ga."), "AP Name");
+    }
+
+    @Test
+    public void findHawaii() {
+        assertEquals(State.HI, State.find("HI"), "Short Name");
+        assertEquals(State.HI, State.find("Hawaii"), "Long Name");
+        assertEquals(State.HI, State.find("Hawai'i"), "Other Name");
+    }
+
+    @Test
+    public void findIdaho() {
+        assertEquals(State.ID, State.find("ID"), "Short Name");
+        assertEquals(State.ID, State.find("Idaho"), "Long Name");
+    }
+
+    @Test
+    public void findIllinois() {
+        assertEquals(State.IL, State.find("IL"), "Short Name");
+        assertEquals(State.IL, State.find("Illinois"), "Long Name");
+        assertEquals(State.IL, State.find("Ill"), "Other Name");
+        assertEquals(State.IL, State.find("Ill."), "AP Name");
+    }
+
+    @Test
+    public void findIndiana() {
+        assertEquals(State.IN, State.find("IN"), "Short Name");
+        assertEquals(State.IN, State.find("Indiana"), "Long Name");
+        assertEquals(State.IN, State.find("Ind"), "Other Name");
+        assertEquals(State.IN, State.find("Ind."), "AP Name");
+    }
+
+    @Test
+    public void findIowa() {
+        assertEquals(State.IA, State.find("IA"), "Short Name");
+        assertEquals(State.IA, State.find("Iowa"), "Long Name");
+    }
+
+    @Test
+    public void findKansas() {
+        assertEquals(State.KS, State.find("KS"), "Short Name");
+        assertEquals(State.KS, State.find("Kansas"), "Long Name");
+        assertEquals(State.KS, State.find("Kan"), "Other Name");
+        assertEquals(State.KS, State.find("Kan."), "AP Name");
+    }
+
+    @Test
+    public void findKentucky() {
+        assertEquals(State.KY, State.find("KY"), "Short Name");
+        assertEquals(State.KY, State.find("Kentucky"), "Long Name");
+        assertEquals(State.KY, State.find("Ky."), "AP Name");
+    }
+
+    @Test
+    public void findLouisiana() {
+        assertEquals(State.LA, State.find("LA"), "Short Name");
+        assertEquals(State.LA, State.find("Louisiana"), "Long Name");
+        assertEquals(State.LA, State.find("La."), "AP Name");
+    }
+
+    @Test
+    public void findMaine() {
+        assertEquals(State.ME, State.find("ME"), "Short Name");
+        assertEquals(State.ME, State.find("Maine"), "Long Name");
+    }
+
+    @Test
+    public void findMaryland() {
+        assertEquals(State.MD, State.find("MD"), "Short Name");
+        assertEquals(State.MD, State.find("Maryland"), "Long Name");
+        assertEquals(State.MD, State.find("Md."), "AP Name");
+    }
+
+    @Test
+    public void findMassachusetts() {
+        assertEquals(State.MA, State.find("MA"), "Short Name");
+        assertEquals(State.MA, State.find("Massachusetts"), "Long Name");
+        assertEquals(State.MA, State.find("Mass"), "Other Name");
+        assertEquals(State.MA, State.find("Mass."), "AP Name");
+    }
+
+    @Test
+    public void findMichigan() {
+        assertEquals(State.MI, State.find("MI"), "Short Name");
+        assertEquals(State.MI, State.find("Michigan"), "Long Name");
+        assertEquals(State.MI, State.find("Mich"), "Other Name");
+        assertEquals(State.MI, State.find("Mich."), "AP Name");
+    }
+
+    @Test
+    public void findMinnesota() {
+        assertEquals(State.MN, State.find("MN"), "Short Name");
+        assertEquals(State.MN, State.find("Minnesota"), "Long Name");
+        assertEquals(State.MN, State.find("Minn"), "Other Name - Minn");
+        assertEquals(State.MN, State.find("Min"), "Other Name - Min");
+        assertEquals(State.MN, State.find("Minn."), "AP Name");
+    }
+
+    @Test
+    public void findMississippi() {
+        assertEquals(State.MS, State.find("MS"), "Short Name");
+        assertEquals(State.MS, State.find("Mississippi"), "Long Name");
+        assertEquals(State.MS, State.find("Miss"), "Other Name");
+        assertEquals(State.MS, State.find("Miss."), "AP Name");
+    }
+
+    @Test
+    public void findMissouri() {
+        assertEquals(State.MO, State.find("MO"), "Short Name");
+        assertEquals(State.MO, State.find("Missouri"), "Long Name");
+        assertEquals(State.MO, State.find("Mo."), "AP Name");
+    }
+
+    @Test
+    public void findMontana() {
+        assertEquals(State.MT, State.find("MT"), "Short Name");
+        assertEquals(State.MT, State.find("Montana"), "Long Name");
+        assertEquals(State.MT, State.find("Mont"), "Other Name");
+        assertEquals(State.MT, State.find("Mont."), "AP Name");
+    }
+
+    @Test
+    public void findNebraska() {
+        assertEquals(State.NE, State.find("NE"), "Short Name");
+        assertEquals(State.NE, State.find("Nebraska"), "Long Name");
+        assertEquals(State.NE, State.find("Neb"), "Other Name");
+        assertEquals(State.NE, State.find("Neb."), "AP Name");
+    }
+
+    @Test
+    public void findNevada() {
+        assertEquals(State.NV, State.find("NV"), "Short Name");
+        assertEquals(State.NV, State.find("Nevada"), "Long Name");
+        assertEquals(State.NV, State.find("Nev"), "Other Name");
+        assertEquals(State.NV, State.find("Nev."), "AP Name");
+    }
+
+    @Test
+    public void findNewHampshire() {
+        assertEquals(State.NH, State.find("NH"), "Short Name");
+        assertEquals(State.NH, State.find("New Hampshire"), "Long Name");
+        assertEquals(State.NH, State.find("N.H."), "AP Name");
+    }
+
+    @Test
+    public void findNewJersey() {
+        assertEquals(State.NJ, State.find("NJ"), "Short Name");
+        assertEquals(State.NJ, State.find("New Jersey"), "Long Name");
+        assertEquals(State.NJ, State.find("N.J."), "AP Name");
+    }
+
+    @Test
+    public void findNewMexico() {
+        assertEquals(State.NM, State.find("NM"), "Short Name");
+        assertEquals(State.NM, State.find("New Mexico"), "Long Name");
+        assertEquals(State.NM, State.find("N.M."), "AP Name");
+    }
+
+    @Test
+    public void findNewYork() {
+        assertEquals(State.NY, State.find("NY"), "Short Name");
+        assertEquals(State.NY, State.find("New York"), "Long Name");
+        assertEquals(State.NY, State.find("N.Y."), "AP Name");
+    }
+
+    @Test
+    public void findNorthCarolina() {
+        assertEquals(State.NC, State.find("NC"), "Short Name");
+        assertEquals(State.NC, State.find("North Carolina"), "Long Name");
+        assertEquals(State.NC, State.find("N.C."), "AP Name");
+    }
+
+    @Test
+    public void findANorthDakota() {
+        assertEquals(State.ND, State.find("ND"), "Short Name");
+        assertEquals(State.ND, State.find("North Dakota"), "Long Name");
+        assertEquals(State.ND, State.find("N.D."), "AP Name");
+    }
+
+    @Test
+    public void findOhio() {
+        assertEquals(State.OH, State.find("OH"), "Short Name");
+        assertEquals(State.OH, State.find("Ohio"), "Long Name");
+    }
+
+    @Test
+    public void findOklahoma() {
+        assertEquals(State.OK, State.find("OK"), "Short Name");
+        assertEquals(State.OK, State.find("Oklahoma"), "Long Name");
+        assertEquals(State.OK, State.find("Okla"), "Other Name");
+        assertEquals(State.OK, State.find("Okla."), "AP Name");
+    }
+
+    @Test
+    public void findOregon() {
+        assertEquals(State.OR, State.find("OR"), "Short Name");
+        assertEquals(State.OR, State.find("Oregon"), "Long Name");
+        assertEquals(State.OR, State.find("Ore"), "Other Name");
+        assertEquals(State.OR, State.find("Ore."), "AP Name");
+    }
+
+    @Test
+    public void findPennsylvania() {
+        assertEquals(State.PA, State.find("PA"), "Short Name");
+        assertEquals(State.PA, State.find("Pennsylvania"), "Long Name");
+        assertEquals(State.PA, State.find("Penn"), "Other Name");
+        assertEquals(State.PA, State.find("Pa."), "AP Name");
+    }
+
+    @Test
+    public void findPuertoRico() {
+        assertEquals(State.PR, State.find("PR"), "Short Name");
+        assertEquals(State.PR, State.find("Puerto Rico"), "Long Name");
+        assertEquals(State.PR, State.find("P.R."), "AP Name");
+    }
+
+    @Test
+    public void findRhodeIsland() {
+        assertEquals(State.RI, State.find("RI"), "Short Name");
+        assertEquals(State.RI, State.find("Rhode Island"), "Long Name");
+        assertEquals(State.RI, State.find("R.I."), "AP Name");
+    }
+
+    @Test
+    public void findSouthCarolina() {
+        assertEquals(State.SC, State.find("SC"), "Short Name");
+        assertEquals(State.SC, State.find("South Carolina"), "Long Name");
+        assertEquals(State.SC, State.find("S.C."), "AP Name");
+    }
+
+    @Test
+    public void findSouthDakota() {
+        assertEquals(State.SD, State.find("SD"), "Short Name");
+        assertEquals(State.SD, State.find("South Dakota"), "Long Name");
+        assertEquals(State.SD, State.find("S.D."), "AP Name");
+    }
+
+    @Test
+    public void findTennessee() {
+        assertEquals(State.TN, State.find("TN"), "Short Name");
+        assertEquals(State.TN, State.find("Tennessee"), "Long Name");
+        assertEquals(State.TN, State.find("Tenn"), "Other Name");
+        assertEquals(State.TN, State.find("Tenn."), "AP Name");
+    }
+
+    @Test
+    public void findTexas() {
+        assertEquals(State.TX, State.find("TX"), "Short Name");
+        assertEquals(State.TX, State.find("Texas"), "Long Name");
+        assertEquals(State.TX, State.find("Tex"), "Other Name - Tex");
+        assertEquals(State.TX, State.find("Tex."), "Other Name - Tex.");
+    }
+
+    @Test
+    public void findUtah() {
+        assertEquals(State.UT, State.find("UT"), "Short Name");
+        assertEquals(State.UT, State.find("Utah"), "Long Name");
+    }
+
+    @Test
+    public void findVermont() {
+        assertEquals(State.VT, State.find("VT"), "Short Name");
+        assertEquals(State.VT, State.find("Vermont"), "Long Name");
+        assertEquals(State.VT, State.find("Vt."), "AP Name");
+    }
+
+    @Test
+    public void findVirginia() {
+        assertEquals(State.VA, State.find("VA"), "Short Name");
+        assertEquals(State.VA, State.find("Virginia"), "Long Name");
+        assertEquals(State.VA, State.find("Va."), "AP Name");
+    }
+
+    @Test
+    public void findWashington() {
+        assertEquals(State.WA, State.find("WA"), "Short Name");
+        assertEquals(State.WA, State.find("Washington"), "Long Name");
+        assertEquals(State.WA, State.find("Wash"), "Other Name");
+        assertEquals(State.WA, State.find("Wash."), "AP Name");
+    }
+
+    @Test
+    public void findWestVirginia() {
+        assertEquals(State.WV, State.find("WV"), "Short Name");
+        assertEquals(State.WV, State.find("West Virginia"), "Long Name");
+        assertEquals(State.WV, State.find("WVa"), "Other Name");
+        assertEquals(State.WV, State.find("W.Va."), "AP Name");
+    }
+
+    @Test
+    public void findWisconsin() {
+        assertEquals(State.WI, State.find("WI"), "Short Name");
+        assertEquals(State.WI, State.find("Wisconsin"), "Long Name");
+        assertEquals(State.WI, State.find("Wis"), "Other Name - Wis");
+        assertEquals(State.WI, State.find("Wis."), "AP Name - Wis.");
+        assertEquals(State.WI, State.find("Wisc"), "Other Name - Wisc");
+        assertEquals(State.WI, State.find("Wisc."), "AP Name - Wisc.");
+    }
+
+    @Test
+    public void findWyoming() {
+        assertEquals(State.WY, State.find("WY"), "Short Name");
+        assertEquals(State.WY, State.find("Wyoming"), "Long Name");
+        assertEquals(State.WY, State.find("Wyo"), "Other Name");
+        assertEquals(State.WY, State.find("Wyo."), "AP Name");
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Brief explanation of the PR and its purpose -->
Migrated enums from the gym-roster-parser so that this library can be used in multiple gym roster modules.

## Related issues
<!-- Which issue(s) does this PR close, resolve or fix. Use Closes #123. Use "Resolves, Closes, or Fixes" to auto-close the issue. -->
Resolves #1 

## Overview of changes
<!-- Provide a summary of key changes -->

#### Describe changes related to the issue(s):
- Migrated: AcademicYear, College, Country, Event, StaffRole and State.

#### Describe any opportune refactorings, if any:
- Renamed CollegeClass to AcademicYear
- Renamed Position to Event

#### Unrelated updates
- Added PR template
- Updated release workflow to generate changelog based on PRs instead of individual commits