### PR TITLE
UK variation; account for periods

### DIFF
--- a/src/main/java/com/doubletuck/gym/common/model/Country.java
+++ b/src/main/java/com/doubletuck/gym/common/model/Country.java
@@ -22,7 +22,7 @@ public enum Country {
     ESP("Spain"),
     FIN("Finland"),
     FRA("France", "FR"),
-    GBR("Great Britain", "GB", "UK", "United Kingdom"),
+    GBR("United Kingdom of Great Britain and Northern Ireland", "GB", "Great Britain", "UK", "United Kingdom"),
     HUN("Hungary", "HU"),
     ITA("Italy", "IT"),
     LVA("Latvia"),
@@ -48,15 +48,16 @@ public enum Country {
     /**
      * Returns the Country enum that matches the given text.
      *
-     * @param   text A name that identifies a Country. The name is not
-     *          case sensitive and can be either the enum name, long name
-     *          or one of the other names associated with the enum value.
+     * @param   text A name that identifies a Country. The name is not case
+     *          sensitive and can be either the enum name, long name or one
+     *          of the other names associated with the enum value. All "."
+     *          are ignored. For example, "G.B." is interpreted as "GB".
      * @return  The Country enum that matches the given text. Null is
      *          returned if no matches are found.
      */
     public static Country find(String text) {
         if (text != null && !text.isEmpty()) {
-            text = text.trim();
+            text = text.trim().replace(".","");
             for (Country country : values()) {
                 if (country.name().equalsIgnoreCase(text) ||
                         country.longName.equalsIgnoreCase(text) ||

--- a/src/test/java/com/doubletuck/gym/common/model/CountryTest.java
+++ b/src/test/java/com/doubletuck/gym/common/model/CountryTest.java
@@ -27,6 +27,12 @@ public class CountryTest {
     }
 
     @Test
+    public void findWhenNameOrOtherNameHasPeriods() {
+        assertEquals(Country.USA, Country.find("U.n.i.t.e.d S.t.a.t.e.s of America"), "Name - Periods");
+        assertEquals(Country.USA, Country.find("U.S."), "Other Name - U.S.");
+    }
+
+    @Test
     public void findOtherNameDespiteCase() {
         assertEquals(Country.GBR, Country.find("united kingdom"), "Lower case");
         assertEquals(Country.GBR, Country.find("UNITED KINGDOM"), "Upper case");
@@ -84,11 +90,14 @@ public class CountryTest {
     }
 
     @Test
-    public void findGreatBritain() {
+    public void findGBRUnitedKingdom() {
         assertEquals(Country.GBR, Country.find("GBR"), "Name");
-        assertEquals(Country.GBR, Country.find("Great Britain"), "Long Name");
-        assertEquals(Country.GBR, Country.find("GB"), "Other name - 2 Character Code");
+        assertEquals(Country.GBR, Country.find("United Kingdom of Great Britain and Northern Ireland"), "Long Name");
+        assertEquals(Country.GBR, Country.find("GB"), "Other name - GB - 2 Character Code");
+        assertEquals(Country.GBR, Country.find("G.B."), "Other name - G.B. - 2 Character Code (with periods)");
+        assertEquals(Country.GBR, Country.find("Great Britain"), "Other name - Great Britain");
         assertEquals(Country.GBR, Country.find("UK"), "Other name - UK");
+        assertEquals(Country.GBR, Country.find("U.K."), "Other name - U.K. (with periods)");
         assertEquals(Country.GBR, Country.find("United Kingdom"), "Other name - United Kingdom");
     }
 
@@ -175,6 +184,7 @@ public class CountryTest {
         assertEquals(Country.USA, Country.find("USA"), "Name");
         assertEquals(Country.USA, Country.find("United States of America"), "Long Name");
         assertEquals(Country.USA, Country.find("US"), "Other name - 2 Character Code");
+        assertEquals(Country.USA, Country.find("U.S."), "Other name - (U.S.) 2 Character Code w/ periods");
     }
 
     @Test


### PR DESCRIPTION
## Summary
<!-- Brief explanation of the PR and its purpose -->
Account for periods in country names. For example, U.S. translates to US --> USA. 
