### PR TITLE
Country code additions: PAN, PER

### DIFF
--- a/src/main/java/com/doubletuck/gym/common/model/Country.java
+++ b/src/main/java/com/doubletuck/gym/common/model/Country.java
@@ -30,6 +30,7 @@ public enum Country {
     NLD("Netherlands", "NL", "Holland"),
     NZL("New Zealand", "NZ"),
     NOR("Norway"),
+    PAN("Panama"),
     PHL("Philippines"),
     ROM("Romania", "RO"),
     SGP("Singapore"),

--- a/src/main/java/com/doubletuck/gym/common/model/Country.java
+++ b/src/main/java/com/doubletuck/gym/common/model/Country.java
@@ -31,6 +31,7 @@ public enum Country {
     NZL("New Zealand", "NZ"),
     NOR("Norway"),
     PAN("Panama"),
+    PER("Peru"),
     PHL("Philippines"),
     ROM("Romania", "RO"),
     SGP("Singapore"),

--- a/src/test/java/com/doubletuck/gym/common/model/CountryTest.java
+++ b/src/test/java/com/doubletuck/gym/common/model/CountryTest.java
@@ -155,6 +155,12 @@ public class CountryTest {
     }
 
     @Test
+    public void findPeru() {
+        assertEquals(Country.PER, Country.find("PER"), "Name");
+        assertEquals(Country.PER, Country.find("Peru"), "Long Name");
+    }
+
+    @Test
     public void findPhilippines() {
         assertEquals(Country.PHL, Country.find("PHL"), "Name");
         assertEquals(Country.PHL, Country.find("Philippines"), "Long Name");

--- a/src/test/java/com/doubletuck/gym/common/model/CountryTest.java
+++ b/src/test/java/com/doubletuck/gym/common/model/CountryTest.java
@@ -149,6 +149,12 @@ public class CountryTest {
     }
 
     @Test
+    public void findPanama() {
+        assertEquals(Country.PAN, Country.find("PAN"), "Name");
+        assertEquals(Country.PAN, Country.find("Panama"), "Long Name");
+    }
+
+    @Test
     public void findPhilippines() {
         assertEquals(Country.PHL, Country.find("PHL"), "Name");
         assertEquals(Country.PHL, Country.find("Philippines"), "Long Name");


### PR DESCRIPTION
## Summary
<!-- Brief explanation of the PR and its purpose -->
Added Panama and Peru to the Country enum as they were first encountered when scraping Boise State's 2019 and 2017 rosters, respectively.
